### PR TITLE
Headline quote: Remove unnecessary line breaks

### DIFF
--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -86,9 +86,7 @@ const Hero = ({ classes, ...props }) => {
         <p>
           <Typography variant="headline" className={quote} component="span">
             “No one may be evicted from their home, or have their home demolished, without an order
-            of court <br />
-             made after considering <br/>
-             all relevant circumstances.”
+            of court made after considering all relevant circumstances.”
           </Typography>
           <Typography className={attribution} component="span">
             - Section 26(3) of the constitution


### PR DESCRIPTION
This is just a quick drive-by fix.